### PR TITLE
fix: not throw error when configure result if test parent is not defined

### DIFF
--- a/lib/collector/hermione.js
+++ b/lib/collector/hermione.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const url = require('url');
 const utils = require('./utils');
 
-const getFilePath = (test) => test && test.file || getFilePath(test.parent);
+const getFilePath = (test) => test && (test.file || getFilePath(test.parent));
 
 exports.configureTestResult = (result) => {
     const filePath = getFilePath(result) || '';

--- a/test/lib/collector/hermione.js
+++ b/test/lib/collector/hermione.js
@@ -14,7 +14,6 @@ describe('collector/hermione', () => {
             return _.defaults(opts || {}, {
                 browserId: 'default-bro',
                 fullTitle: () => 'default full title',
-                file: '/default/path',
                 meta: {url: 'http://default/url'}
             });
         };
@@ -92,6 +91,10 @@ describe('collector/hermione', () => {
                 file: 'file/path',
                 url: '/some-path'
             });
+        });
+
+        it('should not throw an error if test has no parent', () => {
+            assert.doesNotThrow(() => hermioneCollector.configureTestResult(mkDataStub_()));
         });
     });
 


### PR DESCRIPTION
/cc @DudaGod 