### PR TITLE
feat: save stacktraces

### DIFF
--- a/hermione.js
+++ b/hermione.js
@@ -16,7 +16,6 @@ module.exports = (hermione, opts) => {
     hermione.on(hermione.events.TEST_PASS, (data) => collector.addSuccess(data));
 
     hermione.on(hermione.events.TEST_FAIL, (data) => collector.addFail(data));
-    hermione.on(hermione.events.SUITE_FAIL, (data) => collector.addFail(data));
 
     hermione.on(hermione.events.TEST_PENDING, (data) => collector.addSkipped(data));
 

--- a/lib/collector/data-collector/gemini.js
+++ b/lib/collector/data-collector/gemini.js
@@ -23,6 +23,6 @@ module.exports = class GeminiDataCollector extends DataCollector {
         test.duration = Date.now() - this._startTime[id];
         delete this._startTime[id];
 
-        this._data[id] = test;
+        super.append(test);
     }
 };

--- a/lib/collector/data-collector/index.js
+++ b/lib/collector/data-collector/index.js
@@ -2,6 +2,12 @@
 
 const _ = require('lodash');
 
+function customMerger(objValue, srcValue) {
+    if (_.isArray(objValue)) {
+        return objValue.concat(srcValue);
+    }
+}
+
 module.exports = class DataCollector {
     static create() {
         return new DataCollector();
@@ -13,6 +19,11 @@ module.exports = class DataCollector {
 
     append(test) {
         const id = this._generateId(test);
+
+        if (this._data[id]) {
+            this._data[id] = _.mergeWith(this._data[id], test, customMerger);
+            return;
+        }
 
         this._data[id] = test;
     }

--- a/lib/collector/gemini.js
+++ b/lib/collector/gemini.js
@@ -17,4 +17,10 @@ module.exports = class GeminiCollector extends Collector {
         const test = this._toolCollector.configureTestResult(result);
         this._dataCollector.saveStartTime(test);
     }
+
+    addRetry(result) {
+        this._toolCollector.isFailedTest(result)
+            ? this.addFail(result)
+            : this.addError(result);
+    }
 };

--- a/lib/collector/index.js
+++ b/lib/collector/index.js
@@ -22,7 +22,13 @@ module.exports = class Collector {
     }
 
     addFail(result) {
-        this._addTestResult(result, {status: 'fail'});
+        const error = result.err.stack;
+
+        this._addTestResult(result, {
+            status: 'fail',
+            errorReason: error,
+            retries: [{error}]
+        });
     }
 
     addSkipped(result) {
@@ -33,15 +39,16 @@ module.exports = class Collector {
     }
 
     addRetry(result) {
-        this._toolCollector.isFailedTest(result)
-            ? this.addFail(result)
-            : this.addError(result);
+        this.addFail(result);
     }
 
     addError(result) {
+        const error = result.stack || result.message || '';
+
         this._addTestResult(result, {
             status: 'error',
-            errorReason: result.stack || result.message || ''
+            errorReason: error,
+            retries: [{error}]
         });
     }
 

--- a/lib/collector/tool/hermione.js
+++ b/lib/collector/tool/hermione.js
@@ -24,10 +24,6 @@ exports.configureTestResult = (result) => {
     return testResult;
 };
 
-exports.isFailedTest = (result) => {
-    return result.state === 'failed' || result.hook && result.hook.state === 'failed';
-};
-
 exports.getSkipReason = (result) => {
     const findSkipReason = (test) => test.parent && findSkipReason(test.parent) || test.skipReason;
 

--- a/test/hermione.js
+++ b/test/hermione.js
@@ -90,15 +90,13 @@ describe('json-reporter/hermione', () => {
             assert.calledOnceWith(Collector.prototype.addSuccess, data);
         });
 
-        ['TEST_FAIL', 'SUITE_FAIL'].forEach((eventName) => {
-            it('should call appropriate method for failed test', () => {
-                const data = {foo: 'bar'};
-                sandbox.stub(Collector.prototype, 'addFail');
+        it('should call appropriate method for failed test', () => {
+            const data = {foo: 'bar'};
+            sandbox.stub(Collector.prototype, 'addFail');
 
-                hermione.emit(hermione.events[eventName], data);
+            hermione.emit(hermione.events.TEST_FAIL, data);
 
-                assert.calledOnceWith(Collector.prototype.addFail, data);
-            });
+            assert.calledOnceWith(Collector.prototype.addFail, data);
         });
 
         it('should call appropriate method for skipped test', () => {

--- a/test/lib/collector/data-collector/index.js
+++ b/test/lib/collector/data-collector/index.js
@@ -49,14 +49,14 @@ describe('collector/data-collector/index', () => {
         });
     });
 
-    it('should replace the existing test in data collector', () => {
+    it('should merge the existing test in data collector with new one', () => {
         const dataCollector = DataCollector.create({});
 
-        dataCollector.append({foo: 'bar'});
-        dataCollector.append({foo: 'baz'});
+        dataCollector.append({foo: 'bar', arr: [1]});
+        dataCollector.append({foo: 'baz', arr: [2]});
 
         assert.deepEqual(dataCollector.getData(), {
-            '': {foo: 'baz'}
+            '': {foo: 'baz', arr: [1, 2]}
         });
     });
 });

--- a/test/lib/collector/tool/hermione.js
+++ b/test/lib/collector/tool/hermione.js
@@ -106,26 +106,6 @@ describe('collector/tool/hermione', () => {
         });
     });
 
-    describe('isFailedTest', () => {
-        it('should return "true" if test is failed', () => {
-            assert.isTrue(hermioneToolCollector.isFailedTest({state: 'failed'}));
-        });
-
-        it('should return "true" if hook is failed', () => {
-            const result = {hook: {
-                state: 'failed'
-            }};
-
-            assert.isTrue(hermioneToolCollector.isFailedTest(result));
-        });
-
-        it('should return "false" if test and hook are not failed', () => {
-            const result = {hook: {}};
-
-            assert.isFalse(hermioneToolCollector.isFailedTest(result));
-        });
-    });
-
     describe('getSkipReason', () => {
         it('should return default skip reason if "skipReason" is not specified', () => {
             assert.strictEqual(hermioneToolCollector.getSkipReason({}), 'No skip reason');


### PR DESCRIPTION
Last error's stacktrace goes to `root.errorReason`; all of them are accumulated in `root.retries`.

Obsolete hermione event `SUITE_FAIL` was removed.

Hermione always sets `status: 'fail'` on retries and `toolCollector.isFailedTest` for Hermione was removed as it was broken since long ago.
