### PR TITLE
fix: acknowledge gemini diff in a failed test

### DIFF
--- a/lib/collector/gemini.js
+++ b/lib/collector/gemini.js
@@ -23,4 +23,12 @@ module.exports = class GeminiCollector extends Collector {
             ? this.addFail(result)
             : this.addError(result);
     }
+
+    addFail(result) {
+        if (!result.hasOwnProperty('err') && result.hasOwnProperty('equal')) {
+            result.err = new Error('Images are not equal');
+        }
+
+        super.addFail(result);
+    }
 };

--- a/test/lib/collector/gemini.js
+++ b/test/lib/collector/gemini.js
@@ -167,5 +167,22 @@ describe('collector/gemini', () => {
                 assert.deepEqual(bro.retries, [{error: ''}]);
             });
         });
+
+        it('failed test if images are not equal', () => {
+            const notEqualErrorMessage = 'Images are not equal';
+            const data = {fullName: 'some name', browserId: 'bro', equal: false};
+            const collector = mkGeminiCollector_({
+                isFailedTest: sandbox.stub().returns(true)
+            });
+
+            collector.addRetry(data);
+
+            return saveReport_(collector).then((result) => {
+                const bro = result['some name.bro'];
+                assert.propertyVal(bro, 'status', 'fail');
+                assert.include(bro.errorReason, notEqualErrorMessage);
+                assert.include(bro.retries[0].error, notEqualErrorMessage);
+            });
+        });
     });
 });


### PR DESCRIPTION
In that case no `err` field is available.